### PR TITLE
Support for QT-5.2+

### DIFF
--- a/src/qwebkitplatformplugin.h
+++ b/src/qwebkitplatformplugin.h
@@ -180,7 +180,11 @@ public:
 };
 
 QT_BEGIN_NAMESPACE
-Q_DECLARE_INTERFACE(QWebKitPlatformPlugin, "com.nokia.Qt.WebKit.PlatformPlugin/1.9");
+#if QT_VERSION >= 0x050200
+Q_DECLARE_INTERFACE(QWebKitPlatformPlugin, "org.qt-project.Qt.WebKit.PlatformPlugin/1.9")
+#else
+Q_DECLARE_INTERFACE(QWebKitPlatformPlugin, "com.nokia.Qt.WebKit.PlatformPlugin/1.9")
+#endif
 QT_END_NAMESPACE
 
 #endif // QWEBKITPLATFORMPLUGIN_H


### PR DESCRIPTION
QT5.2 or newer requires use `org.qt-project.Qt.WebKit.PlatformPlugin/1.9` instead of `com.nokia.Qt.WebKit.PlatformPlugin/1.9`
